### PR TITLE
Adds composer.json to load phpmyadmin extension via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "mehrwert/phpmyadmin",
+  "type": "typo3-cms-extension",
+  "description": "",
+  "homepage": "http://typo3.org",
+  "license": ["GPL-2.0+"],
+  "version": "5.1.4",
+  "require": {
+    "typo3/cms-core": ">=6.2.0,<8.0"
+  },
+  "autoload": {
+    "classmap": [
+      "Classes/Hooks"
+    ]
+  },
+  "replace": {
+    "phpmyadmin": "*"
+  }
+}


### PR DESCRIPTION
Tested for TYPO3 7.6.2
