### PR TITLE
[BUGFIX] Resolve dropped PATH_typo3 for TYPO3 10.x

### DIFF
--- a/Classes/Backend/PmaModule.php
+++ b/Classes/Backend/PmaModule.php
@@ -14,6 +14,7 @@ namespace Mehrwert\Phpmyadmin\Backend;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Mehrwert\Phpmyadmin\Utility\EnvironmentUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\HttpUtility;
@@ -157,7 +158,7 @@ class PmaModule
 
             // Try to get the TYPO3 backend uri even if it's installed in a subdirectory
             // Compile logout path and add a slash if the returned string does not start with
-            $path_typo3 = substr(PATH_typo3, strlen($typo3DocumentRoot), strlen(PATH_typo3));
+            $path_typo3 = substr(EnvironmentUtility::getBackendPath(), strlen($typo3DocumentRoot), strlen(EnvironmentUtility::getBackendPath()));
             $path_typo3 = (substr($path_typo3, 0, 1) != '/' ? '/' . $path_typo3 : $path_typo3);
             $_SESSION['PMA_LogoutURL'] = $path_typo3 . 'logout.php';
 

--- a/Classes/Hooks/BeUserAuthLogOffHook.php
+++ b/Classes/Hooks/BeUserAuthLogOffHook.php
@@ -14,6 +14,7 @@ namespace Mehrwert\Phpmyadmin\Hooks;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Mehrwert\Phpmyadmin\Utility\EnvironmentUtility;
 use \TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 /**
@@ -71,7 +72,7 @@ class BeUserAuthLogOffHook
             session_start();
 
             // Try to get the TYPO3 backend uri even if it's installed in a subdirectory
-            $path_typo3 = substr(PATH_typo3, strlen($_SERVER['DOCUMENT_ROOT']), strlen(PATH_typo3));
+            $path_typo3 = substr(EnvironmentUtility::getBackendPath(), strlen($_SERVER['DOCUMENT_ROOT']), strlen(EnvironmentUtility::getBackendPath()));
             $path_typo3 = (substr($path_typo3, 0, 1) != '/' ? '/' . $path_typo3 : $path_typo3);
 
             $_SESSION['PMA_LogoutURL'] = $path_typo3 . 'logout.php';

--- a/Classes/Utility/EnvironmentUtility.php
+++ b/Classes/Utility/EnvironmentUtility.php
@@ -1,0 +1,66 @@
+<?php
+namespace Mehrwert\Phpmyadmin\Utility;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Utilities for the phpMyAdmin third party database Administration Tool
+ *
+ * @package        TYPO3
+ * @subpackage    tx_phpmyadmin
+ * @author        mehrwert <typo3@mehrwert.de>
+ * @license        GPL
+ */
+class EnvironmentUtility
+{
+
+    /**
+     * The TYPO3 public web folder
+     *
+     * @var string
+     */
+    protected static $publicPath;
+
+    /**
+     * The TYPO3 public web folder.
+     *
+     * Backwards compatibility with TYPO3 v8
+     *
+     * @return string
+     */
+    public static function getPublicPath()
+    {
+        if (empty(self::$publicPath)) {
+            if (class_exists('\\TYPO3\\CMS\\Core\\Core\\Environment')) {
+                self::$publicPath = \TYPO3\CMS\Core\Core\Environment::getPublicPath();
+            } else {
+                self::$publicPath = rtrim(PATH_site, '/');
+            }
+        }
+
+        return self::$publicPath;
+    }
+
+    /**
+     * The TYPO3 backend folder.
+     *
+     * Backwards compatibility with TYPO3 v8
+     *
+     * @return string
+     */
+    public static function getBackendPath()
+    {
+        return self::getPublicPath() . '/typo3';
+    }
+}


### PR DESCRIPTION
Dear mehrwert team,

your current version seems to fail to work in TYPO3 v10 as it requires the constant PATH_typo3 which has been dropped for TYPO3 v10. I added a switch and check that it works for TYPO3 v10.4.5 (did not check it for v8 and v9 though). Maybe you want to use it.

Greetings
Alex 