### PR TITLE
[BUGFIX] Allow symlinks in subfolders

### DIFF
--- a/Classes/Backend/PmaModule.php
+++ b/Classes/Backend/PmaModule.php
@@ -117,12 +117,6 @@ class PmaModule
         // PMA uses relative file inclusion, so we need to ensure a proper include_path
         @set_include_path($this->MCONF['PMA_absolute_path'] . PATH_SEPARATOR . get_include_path());
 
-        // Path to web dir
-        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 9000000) {
-            $this->MCONF['PMA_relative_path'] = PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath('phpmyadmin')) . $this->MCONF['PMA_subdir'];
-        } else {
-            $this->MCONF['PMA_relative_path'] = ExtensionManagementUtility::siteRelPath('phpmyadmin') . $this->MCONF['PMA_subdir'];
-        }
         // If phpMyAdmin is configured in the conf.php script, we continue to load it...
         if ($this->MCONF['PMA_absolute_path'] && @is_dir($this->MCONF['PMA_absolute_path'])) {
 
@@ -152,9 +146,7 @@ class PmaModule
             $_SESSION['PMA_hideOtherDBs'] = $extensionConfiguration['hideOtherDBs'];
 
             // Get signon uri for redirect
-            $path_ext = substr($extPath, strlen($typo3DocumentRoot), strlen($extPath));
-            $path_ext = (substr($path_ext, 0, 1) != '/' ? '/' . $path_ext : $path_ext);
-            $path_pma = $path_ext . $this->MCONF['PMA_subdir'];
+            $path_pma = PathUtility::getAbsoluteWebPath($extPath . $this->MCONF['PMA_subdir']);
             $_SESSION['PMA_SignonURL'] = $path_pma . 'index.php';
 
             // Try to get the TYPO3 backend uri even if it's installed in a subdirectory


### PR DESCRIPTION
If you have TYPO3 deployed to a certain folder,
which is then symlinked to a subfolder,
then the DOCUMENT_ROOT is invalid.

Instead, the getAbsoluteWebPath() method,
available since TYPO3 v7, can be used.