### PR TITLE
[BUGFIX] Only set PHPMyAdmin cookie for BE Users

### DIFF
--- a/Classes/Hooks/BeUserAuthLogOffHook.php
+++ b/Classes/Hooks/BeUserAuthLogOffHook.php
@@ -15,6 +15,7 @@ namespace Mehrwert\Phpmyadmin\Hooks;
  */
 
 use Mehrwert\Phpmyadmin\Utility\EnvironmentUtility;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 /**
@@ -34,7 +35,7 @@ class BeUserAuthLogOffHook
      */
     public function pmaLogOff($params = [], $ref = null)
     {
-        if (isset($GLOBALS['PHP_UNIT_TEST_RUNNING']) === false) {
+        if ($ref instanceof BackendUserAuthentication && isset($GLOBALS['PHP_UNIT_TEST_RUNNING']) === false) {
             // Define the cookie path
             $cookiePath = substr(
                 ExtensionManagementUtility::extPath('phpmyadmin'),


### PR DESCRIPTION
When a frontend user logs in, then the
"BeUserAuthLogOffHook" creates a phpmyadmin cookie
and thus, exposes the usage of EXT:phpmyadmin for website
users even if they never log in to the TYPO3 Backend.

This change adapts the code to only work with BE_USER
log offs, and not frontend users.